### PR TITLE
Hook up react router and add bare Home and About pages

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -6,4 +6,9 @@ router.get('/', function(req, res, next) {
   res.render('index', { title: 'Baking Expeditions' });
 });
 
+/* GET about page. */
+router.get('/about', function(req, res, next) {
+  res.render('index', { title: 'Baking Expeditions' });
+});
+
 module.exports = router;

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -1,9 +1,19 @@
 import React from 'react';
+import { browserHistory, IndexRoute, Route, Router } from 'react-router';
+
+import Layout from './layout/Layout';
+import About from './pages/About';
+import Home from './pages/Home';
 
 class AppRouter extends React.Component {
   render() {
     return (
-      <div>Hello! I'm Rachel. :)</div>
+      <Router history={browserHistory}>
+        <Route path='/' component={Layout}>
+          <IndexRoute component={Home} />
+          <Route path='/about' component={About} />
+        </Route>
+      </Router>
     );
   }
 }

--- a/src/components/layout/Layout.js
+++ b/src/components/layout/Layout.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { IndexLink, Link } from 'react-router';
+
+class Layout extends React.Component {
+  render() {
+    return (
+      <div>
+        <div><IndexLink to='/'>Home</IndexLink></div>
+        <div><Link to='/about'>About</Link></div>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+Layout.propTypes = {
+  children: React.PropTypes.node.isRequired,
+};
+
+export default Layout;

--- a/src/components/pages/About.js
+++ b/src/components/pages/About.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+class About extends React.Component {
+  render() {
+    return (
+      <div>
+        Hi! I'm Rachel. This is the about page.
+      </div>
+    );
+  }
+}
+
+export default About;

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+class Home extends React.Component {
+  render() {
+    return (
+      <div>
+        Welcome to Baking Expeditions!
+      </div>
+    );
+  }
+}
+
+export default Home;


### PR DESCRIPTION
React router (https://github.com/ReactTraining/react-router) is a library for declarative routing, which helps keep the URL always in sync with the components that are rendered.

1. Create bare bones pages for `Home` and `About` pages.
2. Create a `Layout` component, which will be the shared base between all pages. The layout includes the navigation links to the current two pages, `Home` and `About`. The `Layout` component will render the links, and then any of the children passed to the component. For example, to render the `Home` page, we will render:
```
<Layout>
  <Home />
</Layout>
```
`children` is a special React propType, where the `children` are all nodes between the tags, (e.g. `<Home />` in this example.
3. Use react router in `AppRouter`. This is the entry point to the application, and the router decides what to render from the URL. For the home route, `/`, it matches the parent route `/`, which renders `Layout`, as well as the `IndexRoute` (matches '/'), so it passes `Home` as children to `Layout`. For `/about`, it matches the parent route `/` and the Route with `path='/about'`, so it renders `About` as children in `Layout`.
```
<Router history={browserHistory}>
  <Route path='/' component={Layout}>
    <IndexRoute component={Home} />
    <Route path='/about' component={About} />
  </Route>
</Router>
```
4. Add `/about` as a route to the backend in `routes/index.js`. This is necessary since when you visit http://localhost:3000/about, the server must match that route, then render `index.ejs`, which finally loads the `AppRouter`/React router code.

**Test Plan:**
Visit http://localhost:3000 and verify you can click on the links and are navigated to the correct pages.

<img width="1354" alt="screen shot 2017-01-15 at 4 46 39 pm" src="https://cloud.githubusercontent.com/assets/3781598/21967803/808aa080-db42-11e6-97a3-a597a5663b73.png">
